### PR TITLE
fixed memory explosion

### DIFF
--- a/randomart.c
+++ b/randomart.c
@@ -13,7 +13,7 @@
 #define WIDTH 800
 #define HEIGHT 800
 
-static Arena node_arena = {0};
+static Arena static_arena = {0};
 
 typedef enum {
     NK_X,
@@ -83,75 +83,75 @@ struct Node {
     Node_As as;
 };
 
-Node *node_loc(const char *file, int line, Node_Kind kind)
+Node *node_loc(const char *file, int line, Arena *arena, Node_Kind kind)
 {
-    Node *node = arena_alloc(&node_arena, sizeof(Node));
+    Node *node = arena_alloc(arena, sizeof(Node));
     node->kind = kind;
     node->file = file;
     node->line = line;
     return node;
 }
 
-Node *node_binop_loc(const char *file, int line, Node_Kind kind, Node *lhs, Node *rhs)
+Node *node_binop_loc(const char *file, int line, Arena *arena, Node_Kind kind, Node *lhs, Node *rhs)
 {
-    Node *node = node_loc(file, line, kind);
+    Node *node = node_loc(file, line, arena, kind);
     node->as.binop.lhs = lhs;
     node->as.binop.rhs = rhs;
     return node;
 }
 
-Node *node_number_loc(const char *file, int line, float number)
+Node *node_number_loc(const char *file, int line, Arena *arena, float number)
 {
-    Node *node = node_loc(file, line, NK_NUMBER);
+    Node *node = node_loc(file, line, arena, NK_NUMBER);
     node->as.number = number;
     return node;
 }
-#define node_number(number) node_number_loc(__FILE__, __LINE__, number)
+#define node_number(arena, number) node_number_loc(__FILE__, __LINE__, arena, number)
 
-Node *node_rule_loc(const char *file, int line, int rule)
+Node *node_rule_loc(const char *file, int line, Arena *arena, int rule)
 {
-    Node *node = node_loc(file, line, NK_RULE);
+    Node *node = node_loc(file, line, arena, NK_RULE);
     node->as.rule = rule;
     return node;
 }
-#define node_rule(rule) node_rule_loc(__FILE__, __LINE__, rule)
+#define node_rule(arena, rule) node_rule_loc(__FILE__, __LINE__, arena, rule)
 
-Node *node_boolean_loc(const char *file, int line, bool boolean)
+Node *node_boolean_loc(const char *file, int line, Arena *arena, bool boolean)
 {
-    Node *node = node_loc(file, line, NK_BOOLEAN);
+    Node *node = node_loc(file, line, arena, NK_BOOLEAN);
     node->as.boolean = boolean;
     return node;
 }
-#define node_boolean(boolean) node_boolean_loc(__FILE__, __LINE__, boolean)
+#define node_boolean(arena, boolean) node_boolean_loc(__FILE__, __LINE__, arena, boolean)
 
-#define node_x()      node_loc(__FILE__, __LINE__, NK_X)
-#define node_y()      node_loc(__FILE__, __LINE__, NK_Y)
-#define node_random() node_loc(__FILE__, __LINE__, NK_RANDOM)
+#define node_x(arena)      node_loc(__FILE__, __LINE__, arena, NK_X)
+#define node_y(arena)      node_loc(__FILE__, __LINE__, arena, NK_Y)
+#define node_random(arena) node_loc(__FILE__, __LINE__, arena, NK_RANDOM)
 
-#define node_add(lhs, rhs)  node_binop_loc(__FILE__, __LINE__, NK_ADD,  lhs, rhs)
-#define node_mult(lhs, rhs) node_binop_loc(__FILE__, __LINE__, NK_MULT, lhs, rhs)
-#define node_mod(lhs, rhs)  node_binop_loc(__FILE__, __LINE__, NK_MOD,  lhs, rhs)
-#define node_gt(lhs, rhs)   node_binop_loc(__FILE__, __LINE__, NK_GT,   lhs, rhs)
+#define node_add(arena, lhs, rhs)  node_binop_loc(__FILE__, __LINE__, arena, NK_ADD, lhs, rhs)
+#define node_mult(arena, lhs, rhs) node_binop_loc(__FILE__, __LINE__, arena, NK_MULT, lhs, rhs)
+#define node_mod(arena, lhs, rhs)  node_binop_loc(__FILE__, __LINE__, arena, NK_MOD, lhs, rhs)
+#define node_gt(arena, lhs, rhs)   node_binop_loc(__FILE__, __LINE__, arena, NK_GT, lhs, rhs)
 
-Node *node_triple_loc(const char *file, int line, Node *first, Node *second, Node *third)
+Node *node_triple_loc(const char *file, int line, Arena *arena, Node *first, Node *second, Node *third)
 {
-    Node *node = node_loc(file, line, NK_TRIPLE);
+    Node *node = node_loc(file, line, arena, NK_TRIPLE);
     node->as.triple.first  = first;
     node->as.triple.second = second;
     node->as.triple.third  = third;
     return node;
 }
-#define node_triple(first, second, third) node_triple_loc(__FILE__, __LINE__, first, second, third)
+#define node_triple(arena, first, second, third) node_triple_loc(__FILE__, __LINE__, arena, first, second, third)
 
-Node *node_if_loc(const char *file, int line, Node *cond, Node *then, Node *elze)
+Node *node_if_loc(const char *file, int line, Arena *arena, Node *cond, Node *then, Node *elze)
 {
-    Node *node = node_loc(file, line, NK_IF);
+    Node *node = node_loc(file, line, arena, NK_IF);
     node->as.iff.cond = cond;
     node->as.iff.then = then;
     node->as.iff.elze = elze;
     return node;
 }
-#define node_if(cond, then, elze) node_if_loc(__FILE__, __LINE__, cond, then, elze)
+#define node_if(arena, cond, then, elze) node_if_loc(__FILE__, __LINE__, arena, cond, then, elze)
 
 void node_print(Node *node)
 {
@@ -281,11 +281,11 @@ bool expect_triple(Node *expr)
     return true;
 }
 
-Node *eval(Node *expr, float x, float y)
+Node *eval(Node *expr, Arena *arena, float x, float y)
 {
     switch (expr->kind) {
-    case NK_X:      return node_number_loc(expr->file, expr->line, x);
-    case NK_Y:      return node_number_loc(expr->file, expr->line, y);
+    case NK_X:      return node_number_loc(expr->file, expr->line, arena, x);
+    case NK_Y:      return node_number_loc(expr->file, expr->line, arena, y);
     case NK_BOOLEAN:
     case NK_NUMBER: return expr;
     case NK_RANDOM:
@@ -294,57 +294,57 @@ Node *eval(Node *expr, float x, float y)
         return NULL;
     }
     case NK_ADD: {
-        Node *lhs = eval(expr->as.binop.lhs, x, y);
+        Node *lhs = eval(expr->as.binop.lhs, arena, x, y);
         if (!lhs) return NULL;
         if (!expect_number(lhs)) return NULL;
-        Node *rhs = eval(expr->as.binop.rhs, x, y);
+        Node *rhs = eval(expr->as.binop.rhs, arena, x, y);
         if (!rhs) return NULL;
         if (!expect_number(rhs)) return NULL;
-        return node_number_loc(expr->file, expr->line, lhs->as.number + rhs->as.number);
+        return node_number_loc(expr->file, expr->line, arena, lhs->as.number + rhs->as.number);
     }
     case NK_MULT: {
-        Node *lhs = eval(expr->as.binop.lhs, x, y);
+        Node *lhs = eval(expr->as.binop.lhs, arena, x, y);
         if (!lhs) return NULL;
         if (!expect_number(lhs)) return NULL;
-        Node *rhs = eval(expr->as.binop.rhs, x, y);
+        Node *rhs = eval(expr->as.binop.rhs, arena, x, y);
         if (!rhs) return NULL;
         if (!expect_number(rhs)) return NULL;
-        return node_number_loc(expr->file, expr->line, lhs->as.number * rhs->as.number);
+        return node_number_loc(expr->file, expr->line, arena, lhs->as.number * rhs->as.number);
     }
     case NK_MOD: {
-        Node *lhs = eval(expr->as.binop.lhs, x, y);
+        Node *lhs = eval(expr->as.binop.lhs, arena, x, y);
         if (!lhs) return NULL;
         if (!expect_number(lhs)) return NULL;
-        Node *rhs = eval(expr->as.binop.rhs, x, y);
+        Node *rhs = eval(expr->as.binop.rhs, arena, x, y);
         if (!rhs) return NULL;
         if (!expect_number(rhs)) return NULL;
-        return node_number_loc(expr->file, expr->line, fmodf(lhs->as.number, rhs->as.number));
+        return node_number_loc(expr->file, expr->line, arena, fmodf(lhs->as.number, rhs->as.number));
     }
     case NK_GT: {
-        Node *lhs = eval(expr->as.binop.lhs, x, y);
+        Node *lhs = eval(expr->as.binop.lhs, arena, x, y);
         if (!lhs) return NULL;
         if (!expect_number(lhs)) return NULL;
-        Node *rhs = eval(expr->as.binop.rhs, x, y);
+        Node *rhs = eval(expr->as.binop.rhs, arena, x, y);
         if (!rhs) return NULL;
         if (!expect_number(rhs)) return NULL;
-        return node_boolean_loc(expr->file, expr->line, lhs->as.number > rhs->as.number);
+        return node_boolean_loc(expr->file, expr->line, arena, lhs->as.number > rhs->as.number);
     }
     case NK_TRIPLE: {
-        Node *first = eval(expr->as.triple.first, x, y);
+        Node *first = eval(expr->as.triple.first, arena, x, y);
         if (!first) return NULL;
-        Node *second = eval(expr->as.triple.second, x, y);
+        Node *second = eval(expr->as.triple.second, arena, x, y);
         if (!second) return NULL;
-        Node *third = eval(expr->as.triple.third, x, y);
+        Node *third = eval(expr->as.triple.third, arena, x, y);
         if (!third) return NULL;
-        return node_triple_loc(expr->file, expr->line, first, second, third);
+        return node_triple_loc(expr->file, expr->line, arena, first, second, third);
     }
     case NK_IF: {
-        Node *cond = eval(expr->as.iff.cond, x, y);
+        Node *cond = eval(expr->as.iff.cond, arena, x, y);
         if (!cond) return NULL;
         if (!expect_boolean(cond)) return NULL;
-        Node *then = eval(expr->as.iff.then, x, y);
+        Node *then = eval(expr->as.iff.then, arena, x, y);
         if (!then) return NULL;
-        Node *elze = eval(expr->as.iff.elze, x, y);
+        Node *elze = eval(expr->as.iff.elze, arena, x, y);
         if (!elze) return NULL;
         return cond->as.boolean ? then : elze;
     }
@@ -353,9 +353,9 @@ Node *eval(Node *expr, float x, float y)
     }
 }
 
-bool eval_func(Node *f, float x, float y, Color *c)
+bool eval_func(Node *f, Arena *arena, float x, float y, Color *c)
 {
-    Node *result = eval(f, x, y);
+    Node *result = eval(f, arena, x, y);
     if (!result) return false;
     if (!expect_triple(result)) return false;
     if (!expect_number(result->as.triple.first)) return false;
@@ -369,13 +369,14 @@ bool eval_func(Node *f, float x, float y, Color *c)
 
 bool render_pixels(Node *f)
 {
+    Arena arena = {0};
     for (size_t y = 0; y < HEIGHT; ++y) {
         float ny = (float)y/HEIGHT*2.0f - 1;
         for (size_t x = 0; x < WIDTH; ++x) {
             float nx = (float)x/WIDTH*2.0f - 1;
             Color c;
-            if (!eval_func(f, nx, ny, &c)) return false;
-
+            if (!eval_func(f, &arena, nx, ny, &c)) return false;
+            arena_reset(&arena);
             size_t index = y*WIDTH + x;
             pixels[index].r = (c.r + 1)/2*255;
             pixels[index].g = (c.g + 1)/2*255;
@@ -419,14 +420,14 @@ void grammar_print(Grammar grammar)
     }
 }
 
-Node *gen_rule(Grammar grammar, size_t rule, int depth);
+Node *gen_rule(Grammar grammar, Arena *arena, size_t rule, int depth);
 
 float rand_float(void)
 {
     return (float) rand() / (float) RAND_MAX;
 }
 
-Node *gen_node(Grammar grammar, Node *node, int depth)
+Node *gen_node(Grammar grammar, Arena *arena, Node *node, int depth)
 {
     switch (node->kind) {
     case NK_X:
@@ -439,34 +440,34 @@ Node *gen_node(Grammar grammar, Node *node, int depth)
     case NK_MULT:
     case NK_MOD:
     case NK_GT:
-        Node *lhs = gen_node(grammar, node->as.binop.lhs, depth);
+        Node *lhs = gen_node(grammar, arena, node->as.binop.lhs, depth);
         if (!lhs) return NULL;
-        Node *rhs = gen_node(grammar, node->as.binop.rhs, depth);
+        Node *rhs = gen_node(grammar, arena, node->as.binop.rhs, depth);
         if (!rhs) return NULL;
-        return node_binop_loc(node->file, node->line, node->kind, lhs, rhs);
+        return node_binop_loc(node->file, node->line, arena, node->kind, lhs, rhs);
 
     case NK_TRIPLE:
-        Node *first  = gen_node(grammar, node->as.triple.first, depth);
+        Node *first  = gen_node(grammar, arena, node->as.triple.first, depth);
         if (!first) return NULL;
-        Node *second = gen_node(grammar, node->as.triple.second, depth);
+        Node *second = gen_node(grammar, arena, node->as.triple.second, depth);
         if (!second) return NULL;
-        Node *third  = gen_node(grammar, node->as.triple.third, depth);
+        Node *third  = gen_node(grammar, arena, node->as.triple.third, depth);
         if (!third) return NULL;
-        return node_triple_loc(node->file, node->line, first, second, third);
+        return node_triple_loc(node->file, node->line, arena, first, second, third);
     case NK_IF:
-        Node *cond = gen_node(grammar, node->as.iff.cond, depth);
+        Node *cond = gen_node(grammar, arena, node->as.iff.cond, depth);
         if (!cond) return NULL;
-        Node *then = gen_node(grammar, node->as.iff.then, depth);
+        Node *then = gen_node(grammar, arena, node->as.iff.then, depth);
         if (!then) return NULL;
-        Node *elze = gen_node(grammar, node->as.iff.elze, depth);
+        Node *elze = gen_node(grammar, arena, node->as.iff.elze, depth);
         if (!elze) return NULL;
-        return node_if_loc(node->file, node->line, cond, then, elze);
+        return node_if_loc(node->file, node->line, arena, cond, then, elze);
 
     case NK_RULE:
-        return gen_rule(grammar, node->as.rule, depth - 1);
+        return gen_rule(grammar, arena, node->as.rule, depth - 1);
 
     case NK_RANDOM:
-        return node_number_loc(node->file, node->line, rand_float()*2.0f - 1.0f);
+        return node_number_loc(node->file, node->line, arena, rand_float()*2.0f - 1.0f);
 
     case COUNT_NK:
     default:
@@ -476,7 +477,7 @@ Node *gen_node(Grammar grammar, Node *node, int depth)
 
 #define GEN_RULE_MAX_ATTEMPTS 100
 
-Node *gen_rule(Grammar grammar, size_t rule, int depth)
+Node *gen_rule(Grammar grammar, Arena *arena, size_t rule, int depth)
 {
     if (depth <= 0) return NULL;
 
@@ -493,7 +494,7 @@ Node *gen_rule(Grammar grammar, size_t rule, int depth)
         for (size_t i = 0; i < branches->count; ++i) {
             t += branches->items[i].probability;
             if (t >= p) {
-                node = gen_node(grammar, branches->items[i].node, depth - 1);
+                node = gen_node(grammar, arena, branches->items[i].node, depth - 1);
                 break;
             }
         }
@@ -512,47 +513,47 @@ int main()
     int a = 1;
     int c = 2;
 
-    arena_da_append(&node_arena, &branches, ((Grammar_Branch) {
-        .node = node_triple(node_rule(c), node_rule(c), node_rule(c)),
+    arena_da_append(&static_arena, &branches, ((Grammar_Branch) {
+        .node = node_triple(&static_arena, node_rule(&static_arena, c), node_rule(&static_arena, c), node_rule(&static_arena, c)),
         .probability = 1.0f
     }));
-    arena_da_append(&node_arena, &grammar, branches);
+    arena_da_append(&static_arena, &grammar, branches);
     memset(&branches, 0, sizeof(branches));
 
-    arena_da_append(&node_arena, &branches, ((Grammar_Branch) {
-        .node = node_random(),
+    arena_da_append(&static_arena, &branches, ((Grammar_Branch) {
+        .node = node_random(&static_arena),
         .probability = 1.0/3.0,
     }));
-    arena_da_append(&node_arena, &branches, ((Grammar_Branch) {
-        .node = node_x(),
+    arena_da_append(&static_arena, &branches, ((Grammar_Branch) {
+        .node = node_x(&static_arena),
         .probability = 1.0/3.0,
     }));
-    arena_da_append(&node_arena, &branches, ((Grammar_Branch) {
-        .node = node_y(),
+    arena_da_append(&static_arena, &branches, ((Grammar_Branch) {
+        .node = node_y(&static_arena),
         .probability = 1.0/3.0,
     }));
-    arena_da_append(&node_arena, &grammar, branches);
+    arena_da_append(&static_arena, &grammar, branches);
     memset(&branches, 0, sizeof(branches));
 
-    arena_da_append(&node_arena, &branches, ((Grammar_Branch) {
-        .node = node_rule(a),
+    arena_da_append(&static_arena, &branches, ((Grammar_Branch) {
+        .node = node_rule(&static_arena, a),
         .probability = 1.f/4.f,
         // .probability = 1.f/2.f,
     }));
-    arena_da_append(&node_arena, &branches, ((Grammar_Branch) {
-        .node = node_add(node_rule(c), node_rule(c)),
+    arena_da_append(&static_arena, &branches, ((Grammar_Branch) {
+        .node = node_add(&static_arena, node_rule(&static_arena, c), node_rule(&static_arena, c)),
         .probability = 3.f/8.f,
         // .probability = 1.f/4.f,
     }));
-    arena_da_append(&node_arena, &branches, ((Grammar_Branch) {
-        .node = node_mult(node_rule(c), node_rule(c)),
+    arena_da_append(&static_arena, &branches, ((Grammar_Branch) {
+        .node = node_mult(&static_arena, node_rule(&static_arena, c), node_rule(&static_arena, c)),
         .probability = 3.f/8.f,
         // .probability = 1.f/4.f,
     }));
-    arena_da_append(&node_arena, &grammar, branches);
+    arena_da_append(&static_arena, &grammar, branches);
     memset(&branches, 0, sizeof(branches));
 
-    Node *f = gen_rule(grammar, e, 20);
+    Node *f = gen_rule(grammar, &static_arena, e, 40);
     if (!f) {
         fprintf(stderr, "ERROR: the crappy generation process could not terminate\n");
         return 1;

--- a/randomart.c
+++ b/randomart.c
@@ -553,7 +553,7 @@ int main()
     arena_da_append(&static_arena, &grammar, branches);
     memset(&branches, 0, sizeof(branches));
 
-    Node *f = gen_rule(grammar, &static_arena, e, 40);
+    Node *f = gen_rule(grammar, &static_arena, e, 30);
     if (!f) {
         fprintf(stderr, "ERROR: the crappy generation process could not terminate\n");
         return 1;


### PR DESCRIPTION
introduced a second intermediary arena in render_pixels that resets after every pixel is rendered. longer lived nodes instead live in static_arena which is leaked. 