### PR TITLE
Add scope around switch cases with variables (for macOS)

### DIFF
--- a/randomart.c
+++ b/randomart.c
@@ -439,14 +439,15 @@ Node *gen_node(Grammar grammar, Arena *arena, Node *node, int depth)
     case NK_ADD:
     case NK_MULT:
     case NK_MOD:
-    case NK_GT:
+    case NK_GT: {
         Node *lhs = gen_node(grammar, arena, node->as.binop.lhs, depth);
         if (!lhs) return NULL;
         Node *rhs = gen_node(grammar, arena, node->as.binop.rhs, depth);
         if (!rhs) return NULL;
         return node_binop_loc(node->file, node->line, arena, node->kind, lhs, rhs);
+    }
 
-    case NK_TRIPLE:
+    case NK_TRIPLE: {
         Node *first  = gen_node(grammar, arena, node->as.triple.first, depth);
         if (!first) return NULL;
         Node *second = gen_node(grammar, arena, node->as.triple.second, depth);
@@ -454,7 +455,8 @@ Node *gen_node(Grammar grammar, Arena *arena, Node *node, int depth)
         Node *third  = gen_node(grammar, arena, node->as.triple.third, depth);
         if (!third) return NULL;
         return node_triple_loc(node->file, node->line, arena, first, second, third);
-    case NK_IF:
+    }
+    case NK_IF: {
         Node *cond = gen_node(grammar, arena, node->as.iff.cond, depth);
         if (!cond) return NULL;
         Node *then = gen_node(grammar, arena, node->as.iff.then, depth);
@@ -462,6 +464,7 @@ Node *gen_node(Grammar grammar, Arena *arena, Node *node, int depth)
         Node *elze = gen_node(grammar, arena, node->as.iff.elze, depth);
         if (!elze) return NULL;
         return node_if_loc(node->file, node->line, arena, cond, then, elze);
+    }
 
     case NK_RULE:
         return gen_rule(grammar, arena, node->as.rule, depth - 1);


### PR DESCRIPTION
On Apple Clang 15.0.0, compiling the code without the scopes gives a compile error and does not finish compiling.

```
$ ./nob
./nob
[INFO] CMD: cc -Wall -Wextra -Wswitch-enum -ggdb -o randomart randomart.c -lm
randomart.c:443:9: error: expected expression
        Node *lhs = gen_node(grammar, arena, node->as.binop.lhs, depth);
        ^
randomart.c:444:14: error: use of undeclared identifier 'lhs'
        if (!lhs) return NULL;
             ^
randomart.c:447:74: error: use of undeclared identifier 'lhs'; did you mean 'rhs'?
        return node_binop_loc(node->file, node->line, arena, node->kind, lhs, rhs);
                                                                         ^~~
                                                                         rhs
randomart.c:445:15: note: 'rhs' declared here
        Node *rhs = gen_node(grammar, arena, node->as.binop.rhs, depth);
              ^
randomart.c:450:9: error: expected expression
        Node *first  = gen_node(grammar, arena, node->as.triple.first, depth);
        ^
randomart.c:451:14: error: use of undeclared identifier 'first'
        if (!first) return NULL;
             ^
randomart.c:456:63: error: use of undeclared identifier 'first'
        return node_triple_loc(node->file, node->line, arena, first, second, third);
                                                              ^
randomart.c:458:9: error: expected expression
        Node *cond = gen_node(grammar, arena, node->as.iff.cond, depth);
        ^
randomart.c:459:14: error: use of undeclared identifier 'cond'
        if (!cond) return NULL;
             ^
randomart.c:464:59: error: use of undeclared identifier 'cond'
        return node_if_loc(node->file, node->line, arena, cond, then, elze);
                                                          ^
9 errors generated.
```