### PR TITLE
Fix copy-paste error in node_print

### DIFF
--- a/randomart.c
+++ b/randomart.c
@@ -190,7 +190,7 @@ void node_print(Node *node)
         printf("%s", node->as.boolean ? "true" : "false");
         break;
     case NK_GT:
-        printf("mult(");
+        printf("gt(");
         node_print(node->as.binop.lhs);
         printf(", ");
         node_print(node->as.binop.rhs);


### PR DESCRIPTION
Body of the case for `NK_GT` was copy-pasted from case for `NK_MULT` without modifying the "mult(" print value.