### PR TITLE
Add threading

### DIFF
--- a/randomart.c
+++ b/randomart.c
@@ -10,10 +10,9 @@
 #define ARENA_IMPLEMENTATION
 #include "arena.h"
 
-#define N_THREADS 6
-// #define THREADS_ENABLE
+#define N_THREADS 0
 
-#ifdef THREADS_ENABLE
+#if N_THREADS > 0
 #define THREADS_IMPLEMENTATION
 #include "threads.h"
 #endif
@@ -395,13 +394,13 @@ bool render_pixels(Node *f)
     return true;
 }
 
+#if N_THREADS > 0
 typedef struct {
     size_t i;
     Node* f;
     bool ok;
 } render_thread_params;
 
-#ifdef THREADS_ENABLE
 void* thread_render_pixels(void *raw_args) {
     render_thread_params *args = (render_thread_params*)raw_args;
     Arena arena = {0};
@@ -426,7 +425,7 @@ bool render_pixels_threaded(Node* f) {
     bool result = true;
     // TODO: Maybe extract threads into params
     threads_thread *threads = (threads_thread*)malloc(sizeof(threads_thread)*N_THREADS);
-    render_thread_params volatile *params = (render_thread_params*)malloc(sizeof(render_thread_params)*N_THREADS);
+    render_thread_params *params = (render_thread_params*)malloc(sizeof(render_thread_params)*N_THREADS);
     
     for (size_t i = 0; i < N_THREADS; i++) {
         params[i].f = f;

--- a/threads.h
+++ b/threads.h
@@ -37,7 +37,10 @@ int threads_create(threads_thread *thread, void *(*target)(void *), void *args) 
 int threads_join(threads_thread *thread, void **result) {
     void *value;
 #ifdef _WIN32
-    if (!GetExitCodeThread(thread->thread, &value))
+    if (
+        WaitForSingleObject(thread->thread, INFINITE) ||
+        !GetExitCodeThread(thread->thread, &value)
+    )
         return 1;
 #else
     if (pthread_join(thread->thread, &value))

--- a/threads.h
+++ b/threads.h
@@ -1,0 +1,51 @@
+#ifndef THREADS_H
+#define THREADS_H
+
+#ifdef _WIN32
+    #include <windows.h>
+    typedef struct {
+        HANDLE thread;
+    } threads_thread;
+#else
+    #include <pthread.h>
+    typedef struct {
+        pthread_t thread;
+    } threads_thread;
+#endif
+
+int threads_create(threads_thread *thread, void *(*target)(void *), void *args);
+
+#endif
+
+#define THREADS_IMPLEMENTATION
+#ifdef THREADS_IMPLEMENTATION
+
+int threads_create(threads_thread *thread, void *(*target)(void *), void *args) {
+    threads_thread t;
+#ifdef _WIN32
+    if (!(t.thread = CreateThread(NULL, 0, target, args, 0, NULL)))
+        return 1;
+#else
+    if (pthread_create(&t.thread, NULL, target, args))
+        return 1;
+#endif
+    if (thread)
+        *thread = t;
+    return 0;
+}
+
+int threads_join(threads_thread *thread, void **result) {
+    void *value;
+#ifdef _WIN32
+    if (!GetExitCodeThread(thread->thread, &value))
+        return 1;
+#else
+    if (pthread_join(thread->thread, &value))
+        return 1;
+#endif
+    if (result)
+        *result = value;
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
I added really crude (optional) threading to `render_pixels` as a new function `render_pixels_threaded`.

On my machine, with 5000x5000 and 12 threads, I went from 3'08 without threads down to only 45" when enabling them.
