### PR TITLE
Fix `NK_ADD`

### DIFF
--- a/randomart.c
+++ b/randomart.c
@@ -300,7 +300,7 @@ Node *eval(Node *expr, Arena *arena, float x, float y)
         Node *rhs = eval(expr->as.binop.rhs, arena, x, y);
         if (!rhs) return NULL;
         if (!expect_number(rhs)) return NULL;
-        return node_number_loc(expr->file, expr->line, arena, lhs->as.number + rhs->as.number);
+        return node_number_loc(expr->file, expr->line, arena, (lhs->as.number + rhs->as.number) / 2);
     }
     case NK_MULT: {
         Node *lhs = eval(expr->as.binop.lhs, arena, x, y);


### PR DESCRIPTION
Some guy in the youtube comments found a bug

>your sum operation is not correctly defined. According to the paper
>
>""" All functions appearing in the RandomArt algorithm are scaled so that they map the interval [-1; 1] to the interval [-1; 1]. This condition ensures that all randomly generated expression trees are valid. For example, the scaling for the add function is achieved by defining add(x; y)=(x + y)/2
>"""
>Because your add(x;y) is defined as x+y, it means that your sum node generates invalid expression tree and that's why you were able to generate all those beautifully looking non-linear patterns. I'm not sure it's possible to generate images that you did ([4:26:19](https://www.youtube.com/watch?v=3D_h2RE0o0E&t=15979s), [4:26:47](https://www.youtube.com/watch?v=3D_h2RE0o0E&t=16007s) and so on) by using any combination of x,y, add and mult (linear) operands